### PR TITLE
Use production url as api start point (#28)

### DIFF
--- a/front-end/src/api.js
+++ b/front-end/src/api.js
@@ -1,6 +1,5 @@
 import axios from "axios";
 
 export default axios.create({
-  //baseURL: "https://online-movie-store.netlify.com/api"
-  baseURL: "http://23.101.218.7:8080/api"
+  baseURL: "https://online-movie-store.netlify.com/api"
 });


### PR DESCRIPTION
Use HTTPS URL when making API requests.