### PR TITLE
Netlify redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,7 @@ from = "/api/*"
 to = "http://23.101.218.7:8080/api/:splat"
 status = 200
 force = true
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
Currently, the netlify webpage is unable to redirect direct URL paths because they are handled by the react router.

Eg: https://online-movie-store.netlify.com/login will result in a `404` error.
Whereas, clicking the `Login` button will not, because that redirect is handled by the react router.

This pull request will attempt to amend this issue and allow redirects on the production url.

